### PR TITLE
fix: check authdict before accessing any attribute

### DIFF
--- a/changelog.d/15871.bugfix
+++ b/changelog.d/15871.bugfix
@@ -1,3 +1,0 @@
-Checking authdic dictionary before accessing session from it.
-
-Contributed by @prajjawal05

--- a/changelog.d/15871.bugfix
+++ b/changelog.d/15871.bugfix
@@ -1,1 +1,3 @@
 Checking authdic dictionary before accessing session from it.
+
+Contributed by @prajjawal05

--- a/changelog.d/15871.bugfix
+++ b/changelog.d/15871.bugfix
@@ -1,0 +1,1 @@
+Checking authdic dictionary before accessing session from it.

--- a/changelog.d/16153.bugfix
+++ b/changelog.d/16153.bugfix
@@ -1,0 +1,3 @@
+Checking authdict dictionary before accessing session from it.
+
+Contributed by @prajjawal05

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -483,7 +483,7 @@ class AuthHandler:
 
         sid: Optional[str] = None
         authdict = clientdict.pop("auth", {})
-        if "session" in authdict:
+        if authdict and "session" in authdict:
             sid = authdict["session"]
 
         # Convert the URI and method to strings.


### PR DESCRIPTION
* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
